### PR TITLE
Fix DPI awareness initialization

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,14 +2,17 @@
 
 import sys
 import traceback
-from src.dahitter.gui.main_window import MainWindow
-from PySide6.QtWidgets import QApplication
+import ctypes
 
 
 def main():
     """Qt アプリケーションを初期化してメインウィンドウを表示する"""
 
     try:
+        ctypes.windll.shcore.SetProcessDpiAwareness(2)
+        from PySide6.QtWidgets import QApplication
+        from src.dahitter.gui.main_window import MainWindow
+
         app = QApplication(sys.argv)
         win = MainWindow()
         win.show()


### PR DESCRIPTION
## Summary
- move Qt imports inside `main()` so the DPI setting runs before Qt initialization

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6844e318d69c83268049256e604e9c33